### PR TITLE
PR: 인증 객체를 통한 게시글 작성자 추가 로직 구현

### DIFF
--- a/src/main/java/com/metaverse/community_app/article/controller/ArticleController.java
+++ b/src/main/java/com/metaverse/community_app/article/controller/ArticleController.java
@@ -3,9 +3,11 @@ package com.metaverse.community_app.article.controller;
 import com.metaverse.community_app.article.dto.ArticleRequestDto;
 import com.metaverse.community_app.article.dto.ArticleResponseDto;
 import com.metaverse.community_app.article.service.ArticleService;
+import com.metaverse.community_app.auth.domain.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -22,9 +24,9 @@ public class ArticleController {
     public ResponseEntity<ArticleResponseDto> createArticleForBoard(
             @PathVariable Long boardId,
             @RequestPart("articleData") ArticleRequestDto articleRequestDto,
-            @RequestPart(value = "file", required = false) MultipartFile file) {
-
-        ArticleResponseDto articleResponseDto = articleService.createArticle(boardId, articleRequestDto, file);
+            @RequestPart(value = "file", required = false) MultipartFile file,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        ArticleResponseDto articleResponseDto = articleService.createArticle(principalDetails, boardId, articleRequestDto, file);
         return ResponseEntity.status(HttpStatus.CREATED).body(articleResponseDto);
     }
 
@@ -53,16 +55,18 @@ public class ArticleController {
     public ResponseEntity<ArticleResponseDto> updateArticle(
             @PathVariable Long boardId,
             @PathVariable Long id,
-            @RequestBody ArticleRequestDto articleRequestDto) {
-        ArticleResponseDto updatedArticle = articleService.updateArticle(boardId, id, articleRequestDto);
+            @RequestBody ArticleRequestDto articleRequestDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        ArticleResponseDto updatedArticle = articleService.updateArticle(principalDetails, boardId, id, articleRequestDto);
         return ResponseEntity.ok(updatedArticle);
     }
 
     @DeleteMapping("/boards/{boardId}/articles/{id}")
     public ResponseEntity<Void> deleteArticle(
             @PathVariable Long boardId,
-            @PathVariable Long id) {
-        articleService.deleteArticle(boardId, id);
+            @PathVariable Long id,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        articleService.deleteArticle(principalDetails, boardId, id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/metaverse/community_app/article/domain/Article.java
+++ b/src/main/java/com/metaverse/community_app/article/domain/Article.java
@@ -1,5 +1,6 @@
 package com.metaverse.community_app.article.domain;
 
+import com.metaverse.community_app.auth.domain.User;
 import com.metaverse.community_app.board.domain.Board;
 import com.metaverse.community_app.comment.domain.Comment;
 import com.metaverse.community_app.common.domain.TimeStamped;
@@ -32,16 +33,21 @@ public class Article extends TimeStamped {
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<File> files = new ArrayList<>();
 
-    public Article(String title, String content, Board board) {
+    public Article(String title, String content, Board board, User user) {
         this.title = title;
         this.content = content;
         this.board = board;
+        this.user = user;
     }
 
     public void update(String title, String content)  {

--- a/src/main/java/com/metaverse/community_app/article/dto/ArticleResponseDto.java
+++ b/src/main/java/com/metaverse/community_app/article/dto/ArticleResponseDto.java
@@ -18,6 +18,9 @@ public class ArticleResponseDto {
     private String title;
     private String content;
     private String boardTitle;
+    private String authorUsername;
+    private String authorNickname;
+    private String authorEmail;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createAt;
@@ -35,6 +38,16 @@ public class ArticleResponseDto {
         this.modifiedAt = article.getModifiedAt();
 
         this.boardTitle = article.getBoard().getTitle();
+
+        if (article.getUser() != null) {
+            this.authorUsername = article.getUser().getUsername();
+            this.authorNickname = article.getUser().getNickname();
+            this.authorEmail = article.getUser().getEmail();
+        } else {
+            this.authorUsername = null;
+            this.authorNickname = null;
+            this.authorEmail = null;
+        }
 
         if (article.getComments() != null) {
             this.comments = article.getComments().stream()

--- a/src/main/java/com/metaverse/community_app/auth/domain/User.java
+++ b/src/main/java/com/metaverse/community_app/auth/domain/User.java
@@ -1,10 +1,14 @@
 package com.metaverse.community_app.auth.domain;
 
+import com.metaverse.community_app.article.domain.Article;
 import com.metaverse.community_app.common.domain.TimeStamped;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -31,6 +35,9 @@ public class User extends TimeStamped {
     @Column(name = "user_role")
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Article> articles =  new ArrayList<>();
 
     public User(String username, String nickname, String password, String email, UserRole userRole) {
         this.username = username;


### PR DESCRIPTION
- 회원 로그인(권한은 별도 제한 하지 않았음)
<img width="907" height="487" alt="스크린샷 2025-07-22 202007" src="https://github.com/user-attachments/assets/6bcfdc2f-8c76-4d9d-b163-44e85c491c41" />

- Article이 생성 될 때 로그인된 회원(JWT 토큰으로부터 조회하여 Principal 객체로 만들어진 유저 인스턴스)가 추가되어 작성자와 글이 맵핑됨
- 이를 통해 해당 회원만 수정, 삭제 할 수 있도록 제어하는 로직
- 로그인된 "나"의 게시글 보기 등을 구현 할 수 있음
<img width="1351" height="797" alt="스크린샷 2025-07-22 211842" src="https://github.com/user-attachments/assets/3de420ed-75a3-4ccb-b012-03028dfd4960" />

